### PR TITLE
fix C99 build + hash_has crash with empty hash + use const char* key in protos

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -12,7 +12,7 @@
  */
 
 inline void
-hash_set(hash_t *self, char *key, void *val) {
+hash_set(hash_t *self, const char *key, void *val) {
   int ret;
   khiter_t k = kh_put(ptr, self, key, &ret);
   kh_value(self, k) = val;
@@ -23,7 +23,7 @@ hash_set(hash_t *self, char *key, void *val) {
  */
 
 inline void *
-hash_get(hash_t *self, char *key) {
+hash_get(hash_t *self, const char *key) {
   khiter_t k = kh_get(ptr, self, key);
   return k == kh_end(self) ? NULL : kh_value(self, k);
 }
@@ -33,7 +33,7 @@ hash_get(hash_t *self, char *key) {
  */
 
 inline int
-hash_has(hash_t *self, char *key) {
+hash_has(hash_t *self, const char *key) {
   if(!hash_size(self)) return 0;
   khiter_t k = kh_get(ptr, self, key);
   return kh_exist(self, k);
@@ -44,7 +44,7 @@ hash_has(hash_t *self, char *key) {
  */
 
 void
-hash_del(hash_t *self, char *key) {
+hash_del(hash_t *self, const char *key) {
   khiter_t k = kh_get(ptr, self, key);
   kh_del(ptr, self, k);
 }

--- a/hash.c
+++ b/hash.c
@@ -34,6 +34,7 @@ hash_get(hash_t *self, char *key) {
 
 inline int
 hash_has(hash_t *self, char *key) {
+  if(!hash_size(self)) return 0;
   khiter_t k = kh_get(ptr, self, key);
   return kh_exist(self, k);
 }

--- a/hash.h
+++ b/hash.h
@@ -52,7 +52,8 @@ typedef khash_t(ptr) hash_t;
 #define hash_each(self, block) { \
    const char *key; \
    void *val; \
-    for (khiter_t k = kh_begin(self); k < kh_end(self); ++k) { \
+   khiter_t k; \
+    for (k = kh_begin(self); k < kh_end(self); ++k) { \
       if (!kh_exist(self, k)) continue; \
       key = kh_key(self, k); \
       val = kh_value(self, k); \
@@ -66,7 +67,8 @@ typedef khash_t(ptr) hash_t;
 
 #define hash_each_key(self, block) { \
     const char *key; \
-    for (khiter_t k = kh_begin(self); k < kh_end(self); ++k) { \
+    khiter_t k; \
+    for (k = kh_begin(self); k < kh_end(self); ++k) { \
       if (!kh_exist(self, k)) continue; \
       key = kh_key(self, k); \
       block; \
@@ -79,7 +81,8 @@ typedef khash_t(ptr) hash_t;
 
 #define hash_each_val(self, block) { \
     void *val; \
-    for (khiter_t k = kh_begin(self); k < kh_end(self); ++k) { \
+    khiter_t k; \
+    for (k = kh_begin(self); k < kh_end(self); ++k) { \
       if (!kh_exist(self, k)) continue; \
       val = kh_value(self, k); \
       block; \

--- a/hash.h
+++ b/hash.h
@@ -92,16 +92,16 @@ typedef khash_t(ptr) hash_t;
 // protos
 
 void
-hash_set(hash_t *self, char *key, void *val);
+hash_set(hash_t *self, const char *key, void *val);
 
 void *
-hash_get(hash_t *self, char *key);
+hash_get(hash_t *self, const char *key);
 
 int
-hash_has(hash_t *self, char *key);
+hash_has(hash_t *self, const char *key);
 
 void
-hash_del(hash_t *self, char *key);
+hash_del(hash_t *self, const char *key);
 
 void
 hash_clear(hash_t *self);


### PR DESCRIPTION
"khiter_t k" have been declared outside for loop to fix a build error on my system.
gcc version 4.8.1
