### PR TITLE
Fix segmentation fault in `hash_has`

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -35,7 +35,7 @@ hash_get(hash_t *self, char *key) {
 inline int
 hash_has(hash_t *self, char *key) {
   khiter_t k = kh_get(ptr, self, key);
-  return kh_exist(self, k);
+  return k != kh_end(self);
 }
 
 /*


### PR DESCRIPTION
Fixed segmentation fault when running `hash_has` on an empty hash (see attractivechaos/klib#37)